### PR TITLE
Fix for #2: EquationOfState exits early

### DIFF
--- a/dist/EquationOfState.js
+++ b/dist/EquationOfState.js
@@ -11,22 +11,24 @@ var EquationOfState = (function () {
     */
     EquationOfState.prototype.findModeIndex = function (inputs) {
         var inputList = Object.keys(inputs), noInputs = inputList.length, noModes = this.modes.length;
+        var modeNum = -1;
         for (var i = 0; i < noModes; i++) {
             var mode = this.modes[i], matched = true;
             for (var j = 0, len = mode.length; j < len; j++) {
                 if (inputList.indexOf(mode[j]) === -1) {
                     // An property of this mode is not matched in inputs
                     matched = false;
-                    break;
                 }
             }
             if (matched) {
-                return i;
+                modeNum = i;
+                break;
             }
             else {
-                return -1;
+                modeNum = -1;
             }
         }
+        return modeNum;
     };
     return EquationOfState;
 }());

--- a/src/EquationOfState.ts
+++ b/src/EquationOfState.ts
@@ -22,6 +22,8 @@ export abstract class EquationOfState
             noInputs = inputList.length,
             noModes = this.modes.length;
 
+        let modeNum = -1;
+
         for (let i = 0; i < noModes; i++)
         {
             let mode = this.modes[i],
@@ -33,18 +35,19 @@ export abstract class EquationOfState
                 {
                     // An property of this mode is not matched in inputs
                     matched = false;
-                    break;
                 }
             }
 
             if (matched)
             {
-                return i;
+                modeNum = i;
+                break;
             }
             else
             {
-                return -1;
+                modeNum = -1;
             }
         }
+        return modeNum;
     }
 }


### PR DESCRIPTION
EquationOfState exits too early, as the return statement forces the loop to quit on the first instance. Updated to store the value of the mode and quit once a match has been found;